### PR TITLE
add detailed port, comment and other attributes to rules

### DIFF
--- a/APACHE/Map.pm
+++ b/APACHE/Map.pm
@@ -1,11 +1,12 @@
 # Plugin "Firewall Rules" OCSInventory
 # Author: Léa DROGUET
+# Contributor : Malika Mebrouk (added fields: SOURCE_PORT, DESTINATION_PORT, COMMENT, and OTHER)
 
 package Apache::Ocsinventory::Plugins::Firewallrules::Map;
- 
+
 use strict;
- 
 use Apache::Ocsinventory::Map;
+
 $DATA_MAP{firewallrules} = {
    mask => 0,
    multi => 1,
@@ -15,16 +16,18 @@ $DATA_MAP{firewallrules} = {
    writeDiff => 0,
    cache => 0,
    fields => {
-       RULE_ID => {},
-       DISPLAYNAME => {},
-       DESCRIPTION => {},
-       SOURCE => {},
-       DESTINATION => {},
-       ENABLED => {},
-       DIRECTION => {},
-       ACTION => {},
-       PORT => {},
-       PROTOCOL => {}
+       RULE_ID          => {},
+       DISPLAYNAME      => {},
+       SOURCE           => {},
+       SOURCE_PORT      => {},
+       DESTINATION      => {},
+       DESTINATION_PORT => {},
+       DIRECTION        => {},
+       ACTION           => {},
+       PROTOCOL         => {},
+       COMMENT          => {},
+       OTHER            => {},
    }
 };
+
 1;

--- a/agent/Unix/Firewallrules.pm
+++ b/agent/Unix/Firewallrules.pm
@@ -1,84 +1,148 @@
 # Plugin "Firewall Rules" OCSInventory
-# Author: Léa DROGUET
-
-# TODO :
-# must be a better way to skip lines
+# Author: Lea DROGUET
+# Contributor : Malika Mebrouk (rewrites parsing to be chain-aware (INPUT/OUTPUT/FORWARD), uses verbose iptables output per chain, properly parses and maps protocol numbers, extracts comments and src/dst ports (including ranges), tracks interfaces and other flags)
 
 package Ocsinventory::Agent::Modules::Firewallrules;
 
 sub new {
-
-    my $name="firewallrules"; # Name of the module
-
-    my (undef,$context) = @_;
+    my $name = "firewallrules";
+    my (undef, $context) = @_;
     my $self = {};
 
-    #Create a special logger for the module
-    $self->{logger} = new Ocsinventory::Logger ({
+    $self->{logger} = new Ocsinventory::Logger({
         config => $context->{config}
     });
-    $self->{logger}->{header}="[$name]";
-    $self->{context}=$context;
-    $self->{structure}= {
+    $self->{logger}->{header} = "[$name]";
+    $self->{context} = $context;
+    $self->{structure} = {
         name => $name,
-        start_handler => undef,    #or undef if don't use this hook
-        prolog_writer => undef,    #or undef if don't use this hook
-        prolog_reader => undef,    #or undef if don't use this hook
-        inventory_handler => $name."_inventory_handler",    #or undef if don't use this hook
-        end_handler => undef       #or undef if don't use this hook
+        inventory_handler => $name . "_inventory_handler",
     };
     bless $self;
 }
 
-######### Hook methods ############
-sub firewallrules_inventory_handler {
+my %proto_map = (
+    0 => 'IP',    1 => 'ICMP',   2 => 'IGMP',   3 => 'GGP',
+    4 => 'IP-ENCAP', 5 => 'ST',  6 => 'TCP',    8 => 'EGP',
+    9 => 'IGP',   12 => 'PUP',   17 => 'UDP'
+); #add others if needed (see /etc/protocols)
 
+sub firewallrules_inventory_handler {
     my $self = shift;
     my $logger = $self->{logger};
     my $common = $self->{context}->{common};
+    my $current_chain = '';
 
-    # default values for testing
-    $displayName = "iptables rule";
-    $enabled = "TRUE";
-    
+    foreach my $line (_getFirewallRules()) {
+        next if $line =~ /^pkts\s+bytes\s+target/i;
+        next if $line =~ /^\s*$/;
+        next if $line =~ /description/i;
 
-    $logger->debug("Yeah you are in firewallrules_inventory_handler:)");
-    
-    my %rules;
-    my ($direction, $action, $protocol, $opt, $source, $destination, $comment);
-    
-    foreach my $rule (_getFirewallRules()) {
-        if ($rule =~ /^target/) {
+        if ($line =~ /^Chain\s+(\S+)/) {
+            $current_chain = $1;
             next;
         }
-        if ($rule =~ /^\s*$/) {
-            next;
+
+        my $displayName = "iptables";
+        if ($current_chain eq 'INPUT') {
+            $displayName = "INPUT";
+        } elsif ($current_chain eq 'OUTPUT') {
+            $displayName = "OUTPUT";
+        } elsif ($current_chain eq 'FORWARD') {
+            $displayName = "FORWARD";
         }
-        # if line contains "chain", second word is direction
-        if ($rule =~ /Chain/) {
-            (undef, $direction, undef, undef) = split(' ', $rule);
+
+        if (
+            $line =~ /^\s*
+            (\S+)\s+         # pkts
+            (\S+)\s+         # bytes
+            (\S+)\s+         # action
+            (\S+)\s+         # protocol_num
+            (\S+)\s+         # opt
+            (\S+)\s+         # in_if
+            (\S+)\s+         # out_if
+            (\S+)\s+         # source
+            (\S+)\s+         # destination
+            (.*)             # rest
+            $/x
+        ) {
+            my ($pkts, $bytes, $action, $protocol_num, $opt, $in_if, $out_if, $source, $destination, $rest) =
+                ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10);
+
+            # Skip header lines by comparing lowercase strings
+            if (
+                lc($source) eq 'source' or
+                lc($destination) eq 'destination' or
+                lc($action) eq 'target' or
+                lc($protocol_num) eq 'prot' or
+                lc($in_if) eq 'in' or
+                lc($out_if) eq 'out'
+            ) {
+                next;
+            }
+
+            my $protocol = exists $proto_map{$protocol_num} ? $proto_map{$protocol_num} : $protocol_num;
+
+            # Extract comment enclosed in /* ... */
+            my $comment = '';
+            if ($rest =~ /\/\*\s*(.*?)\s*\*\//) {
+                $comment = $1;
+                $rest =~ s/\/\*\s*\Q$comment\E\s*\*\///g;
+            }
+
+            # Extract destination port(s) - support range/multi e.g. 67:68
+            my $dst_port = '';
+            if ($rest =~ /dpts?:([\d:]+)/) {
+                $dst_port = $1;
+                $rest =~ s/dpts?:[\d:]+//g;
+            }
+
+            # Extract source port(s) - support range/multi e.g. 1024:65535
+            my $src_port = '';
+            if ($rest =~ /spts?:([\d:]+)/) {
+                $src_port = $1;
+                $rest =~ s/spts?:[\d:]+//g;
+            }
+
+            # Trim leading/trailing whitespace in rest
+            $rest =~ s/^\s+|\s+$//g;
+            my $other = $rest;
+
+            # Append input/output interfaces to other info if present
+            if (defined $in_if && $in_if ne '*' && $in_if ne '') {
+                $other = "in = $in_if" . ($other ? " $other" : '');
+            }
+            if (defined $out_if && $out_if ne '*' && $out_if ne '') {
+                $other = $other ? "$other out = $out_if" : "out = $out_if";
+            }
+
+            $logger->debug("Parsed rule: action=$action, protocol=$protocol, source=$source, source_port=$src_port, destination=$destination, destination_port=$dst_port, comment=$comment, other=$other, chain=$current_chain");
+
+            push @{$common->{xmltags}->{FIREWALLRULES}}, {
+                DISPLAYNAME      => [$displayName],
+                SOURCE           => [$source],
+                SOURCE_PORT      => [$src_port],
+                DESTINATION      => [$destination],
+                DESTINATION_PORT => [$dst_port], 
+                ACTION           => [$action],
+                PROTOCOL         => [$protocol],
+                COMMENT          => [$comment],
+                OTHER            => [$other]
+            };
         } else {
-            ($action, $protocol, $opt, $source, $destination, $comment, $other) = split(' ', $rule);
+            $logger->debug("Warning: Could not parse firewall rule line: $line");
         }
-
-        push @{$common->{xmltags}->{FIREWALLRULES}},
-        {
-            DISPLAYNAME => [$displayName],
-            DESCRIPTION    => ["$source => $destination"],
-            SOURCE => [$source],
-            DESTINATION => [$destination],
-            ACTION  => [$action],
-            PORT  => ["$comment $other"],
-            PROTOCOL => [$protocol]
-        };
     }
-
 }
 
-
 sub _getFirewallRules {
-    my @rules = `iptables --list -n`;
-    return @rules;
+    my @all_rules;
+    for my $chain ('INPUT', 'OUTPUT', 'FORWARD') {
+        push @all_rules, "Chain $chain\n";
+        push @all_rules, `iptables -L $chain -n -v`;
+    }
+    return @all_rules;
 }
 
 1;
+

--- a/cd_firewallrules/cd_firewallrules.php
+++ b/cd_firewallrules/cd_firewallrules.php
@@ -1,6 +1,7 @@
 <?php
 # Plugin "Firewall Rules" OCSInventory
-# Author: Léa DROGUETT
+# Author: Léa DROGUET
+# Contributor : Malika Mebrouk (adding columns for source/destination ports, comments, and other metadata)
 
  /**
   * This file is used to build a table refering to the plugin and define its 
@@ -35,42 +36,50 @@ $item = info($protectedGet, $protectedPost['systemid'] ?? '');
 
 echo open_form($form_name);
 
+
 if (preg_match('/unix/', $item->USERAGENT)) {
     $list_fields = array(
-        'Name' => 'DISPLAYNAME',
-        'Description' => 'DESCRIPTION',
-        'Source' => 'SOURCE',
-        'Destination' => 'DESTINATION',
-        'Action' => 'ACTION',
-        'Protocol' => 'PROTOCOL',
-        'Port' => 'PORT');
+        'Name'             => 'DISPLAYNAME',
+        'Source'           => 'SOURCE',
+        'Source Port'      => 'SOURCE_PORT',
+        'Destination'      => 'DESTINATION',
+        'Destination Port' => 'DESTINATION_PORT',
+        'Action'           => 'ACTION',
+        'Protocol'         => 'PROTOCOL',
+        'Comment'          => 'COMMENT',
+        'Other'            => 'OTHER',
+    );
 } else {
     $list_fields = array(
-        'Name' => 'DISPLAYNAME',
-        'Description' => 'DESCRIPTION',
-        'Enabled' => 'ENABLED',
-        'Direction' => 'DIRECTION',
-        'Action' => 'ACTION',
-        'Protocol' => 'PROTOCOL',
-        'Port' => 'PORT');
+        'Name'             => 'DISPLAYNAME',
+        'Enabled'          => 'ENABLED',
+        'Direction'        => 'DIRECTION',
+        'Source'           => 'SOURCE',
+        'Source Port'      => 'SOURCE_PORT',
+	'Destination'      => 'DESTINATION',
+        'Destination Port' => 'DESTINATION_PORT',
+        'Action'           => 'ACTION',
+        'Protocol'         => 'PROTOCOL',
+        'Comment'          => 'COMMENT',
+        'Other'            => 'OTHER',
+    );
 }
 
-
-// columns to include at any time and default columns
+// Columns to include at any time and default columns
 $list_col_cant_del = $list_fields;
 $default_fields = $list_fields;
 
-// select columns for table display
+// Select columns for table display
 $sql = prepare_sql_tab($list_fields);
-$sql['SQL']  .= "FROM firewallrules WHERE (hardware_id = $systemid)";
+$sql['SQL']  .= " FROM firewallrules WHERE (hardware_id = $systemid)";
 
 array_push($sql['ARG'], $systemid);
 $tab_options['ARG_SQL'] = $sql['ARG'];
 $tab_options['ARG_SQL_COUNT'] = $systemid;
+
 ajaxtab_entete_fixe($list_fields, $default_fields, $tab_options, $list_col_cant_del);
 
 echo close_form();
-
 
 if ($ajax) {
     ob_end_clean();

--- a/install.php
+++ b/install.php
@@ -1,31 +1,28 @@
 <?php
 /**
- * The following functions are used by the extension engine to generate a new table
- * for the plugin / destroy it on removal.
- */
-
-
-/**
  * This function is called on installation and is used to 
  * create database schema for the plugin
  */
 function extension_install_firewallrules() {
     $commonObject = new ExtensionCommon;
-    $commonObject -> sqlQuery("DROP TABLE IF EXISTS `firewallrules`");
-    $commonObject -> sqlQuery(
+    $commonObject->sqlQuery("DROP TABLE IF EXISTS `firewallrules`");
+    $commonObject->sqlQuery(
         "CREATE TABLE IF NOT EXISTS `firewallrules` (
-        RULE_ID INT(11) NOT NULL AUTO_INCREMENT, 
-        HARDWARE_ID INT(11) NOT NULL,
-        DISPLAYNAME VARCHAR(255) NOT NULL,
-        DESCRIPTION VARCHAR(255) NOT NULL,
-        ENABLED VARCHAR(255) NOT NULL,
-        SOURCE VARCHAR(255) NOT NULL,
-        DESTINATION VARCHAR(255) NOT NULL,
-        DIRECTION VARCHAR(255) NOT NULL,
-        ACTION VARCHAR(255) NOT NULL,
-        PORT VARCHAR(255) NOT NULL,
-        PROTOCOL VARCHAR(255) NOT NULL,
-        PRIMARY KEY (RULE_ID, HARDWARE_ID)) ENGINE=INNODB;"
+            RULE_ID INT(11) NOT NULL AUTO_INCREMENT, 
+            HARDWARE_ID INT(11) NOT NULL,
+            DISPLAYNAME VARCHAR(255) NOT NULL,
+            ENABLED VARCHAR(255) NOT NULL,
+            SOURCE VARCHAR(255) NOT NULL,
+            SOURCE_PORT VARCHAR(255) DEFAULT NULL,
+            DESTINATION VARCHAR(255) NOT NULL,
+            DESTINATION_PORT VARCHAR(255) NOT NULL,
+            DIRECTION VARCHAR(255) NOT NULL,
+            ACTION VARCHAR(255) NOT NULL,
+            PROTOCOL VARCHAR(255) NOT NULL,
+            COMMENT VARCHAR(255) DEFAULT NULL,
+            OTHER VARCHAR(255) DEFAULT NULL,
+            PRIMARY KEY (RULE_ID, HARDWARE_ID)
+        ) ENGINE=INNODB;"
     );
 }
 
@@ -36,7 +33,7 @@ function extension_install_firewallrules() {
 function extension_delete_firewallrules()
 {
     $commonObject = new ExtensionCommon;
-    $commonObject -> sqlQuery("DROP TABLE IF EXISTS `firewallrules`");
+    $commonObject->sqlQuery("DROP TABLE IF EXISTS `firewallrules`");
 }
 
 /**
@@ -44,7 +41,6 @@ function extension_delete_firewallrules()
  */
 function extension_upgrade_firewallrules()
 {
-
+    // You may add upgrade logic here if needed in future
 }
-
 ?>


### PR DESCRIPTION
I am working on a project involving OCSInventory. These changes extend the existing Firewall Rules plugin by adding detailed parsing and metadata for firewall rules, including ports, comments, and additional attributes. This allows more comprehensive data collection and visualization within OCSInventory.  
These updates were necessary on our side to support our specific use case, and I am sharing them publicly to contribute back to the community. Many thanks to the OCSInventory team for their ongoing excellent work on this valuable open-source project.